### PR TITLE
3 show only two top layers by default

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,8 +12,10 @@ if (isIE()) {
   // parse data only if tree not loaded already
   if (getDataFromSessionStorage(repoName + "Tree") === null) {
     let parsedData = parseData(dataHost, dataDict, jsonDataFile);
+    // let parsedTreeChildren = parseData(dataHost, dataDict, jsonTreeFile);
     if(!parsedData.length) throw new Error("index.js: Data error");
     keepDataInSessionStorage(repoName + "Tree", JSON.stringify(parsedData));
+    // keepDataInSessionStorage(repoName + "TreeChildren", JSON.stringify(parsedTreeChildren));
   }
 
   initGraph();

--- a/dag.js
+++ b/dag.js
@@ -375,6 +375,7 @@ function drawTree(drawData,state)
  */
 function NodeExpand(currentNodeId,data)
 {
+    let nodeChildren = [];
     for(let i = 0;i<data.length;i++)
     {
         if(data[i]["parentIds"].includes(currentNodeId))
@@ -397,6 +398,24 @@ function NodeExpand(currentNodeId,data)
             else{
                 shownNodesMap[data[i]["id"]] = 1;
                 currentTree.push(data[i]);
+            }
+            nodeChildren.push(data[i]["id"]);
+        }
+    }
+    for(let i = 0;i<nodeChildren.length;i++)
+    {
+        let nodeGrandChildren = getNodeChildren(nodeChildren[i],data);
+        for(let j = 0;j<nodeGrandChildren.length;j++)
+        {
+            if(shownNodesMap[nodeGrandChildren[j]["id"]] === 1)
+            {
+                for(let k=0;k<currentTree.length;k++)
+                {
+                    if(nodeGrandChildren[j]["id"] === currentTree[k]["id"] && !currentTree[k]["parentIds"].includes(nodeChildren[i]))
+                    {
+                        currentTree[k]["parentIds"].push(nodeChildren[i]);
+                    }
+                }
             }
         }
     }

--- a/dag.js
+++ b/dag.js
@@ -31,7 +31,9 @@ const line = d3
 .x((d) => d.x + nodeWidth/2)
 .y((d) => d.y + nodeHeight/2);
 
-
+/**
+ * Initialize tree with the two top layers nodes
+ */
 function initGraph() {
     // fetch data and render
     let data = JSON.parse(getDataFromSessionStorage(repoName + "Tree"));
@@ -98,7 +100,6 @@ function initGraph() {
   return JSON.parse(allText);
  }
 
-
  /**
   * Performs action after the info label is clicked
   * @param {Object} d clicked info
@@ -113,7 +114,7 @@ function initGraph() {
  }
 
 /**
- * Performs action after the a node is clicked
+ * Performs action after a node is clicked
  * @param {Object} d clicked info
  */
  function onNodeClicked(d) {
@@ -165,7 +166,6 @@ function initGraph() {
       // set new box height
   });
 }
-
 /**
  * Performs graph update. Updates nodes and links.
  * @param {Number} currentNodeId
@@ -190,7 +190,10 @@ function initGraph() {
       }
   });
 }
-
+/**
+ * Toggle between expanding and collapsing node children
+ * @param {Object} d clicked node
+ */
 function onNodeToggleChildrenClicked(d){
     let currentNodeId = d.currentTarget.__data__.data.id;
     let state;
@@ -207,6 +210,11 @@ function onNodeToggleChildrenClicked(d){
     updateTree(currentNodeId,state);
 }
 
+/**
+ * update currentTree after expand/collapse of a node
+ * @param {String} currentNodeId node ID
+ * @param {String} state node to be expanded or collapsed
+ */
 function updateTree(currentNodeId,state){
     let data = JSON.parse(getDataFromSessionStorage(repoName + "Tree"));
     if(state === "expand")
@@ -216,7 +224,7 @@ function updateTree(currentNodeId,state){
     }
     else
     {
-        NodeCollapse(currentNodeId,data);
+        NodeCollapse(currentNodeId);
     }
     for (let i = 0; i < currentTree.length; i++)
     {
@@ -235,6 +243,11 @@ function updateTree(currentNodeId,state){
         .attr('transform', zoomTransform);
 }
 
+/**
+ * draw the tree elements
+ * @param {Array} drawData node ID
+ * @param {String} state initialize or update the tree
+ */
 function drawTree(drawData,state)
 {
     dag = d3.dagStratify()(drawData);
@@ -355,10 +368,13 @@ function drawTree(drawData,state)
         .on("click", onNodeToggleChildrenClicked);
 
 }
-
+/**
+ * Search for nodes children and add them to the currentTree
+ * @param {String} currentNodeId clicked node ID
+ * @param {Array} data tree data
+ */
 function NodeExpand(currentNodeId,data)
 {
-    let childrenIds = [];
     for(let i = 0;i<data.length;i++)
     {
         if(data[i]["parentIds"].includes(currentNodeId))
@@ -382,12 +398,15 @@ function NodeExpand(currentNodeId,data)
                 shownNodesMap[data[i]["id"]] = 1;
                 currentTree.push(data[i]);
             }
-            childrenIds.push(data[i]["id"]);
         }
     }
 }
-
-function NodeCollapse(currentNodeId,data)
+/**
+ * Search for nodes children and remove them from currentTree
+ * If there is a child has children, check if it should be removed, or it has other parents in the currentTree
+ * @param {String} currentNodeId clicked node ID
+ */
+function NodeCollapse(currentNodeId)
 {
     let childrenQueue = [];
     childrenQueue.push(currentNodeId);
@@ -429,7 +448,10 @@ function NodeCollapse(currentNodeId,data)
     }
 }
 
-
+/**
+ * Remove node parents not included in the currentTree
+ * @param {Array} parents node parents
+ */
 function RemoveHiddenParents(parents)
 {
     let j = 0;
@@ -446,6 +468,11 @@ function RemoveHiddenParents(parents)
     }
 }
 
+/**
+ * Update expand/collapse state of node
+ * @param {String} currentNodeId node ID
+ * @param {Array} data tree data
+ */
 function updateShownNodeChildrenMap(currentNodeId,data)
 {
     if(getNodeChildren(currentNodeId,data).length === getNodeChildren(currentNodeId,currentTree).length)

--- a/dag.js
+++ b/dag.js
@@ -9,7 +9,8 @@ let width = 600, height = 400;
 let maxTextLength = 200;
 let nodeWidth = maxTextLength + 20;
 let nodeHeight = 140;
-let map = {};
+let shownNodesMap = {};
+let shownNodeChildrenMap = {};
 let currentTree = [];
 let zoomTransform;
 
@@ -37,20 +38,20 @@ function initGraph() {
     {
         if(data[i]["parentIds"].length === 0)
         {
-            map[data[i]["id"]] = 1;
+            shownNodesMap[data[i]["id"]] = 1;
             currentTree.push(data[i]);
             NodeExpand(data[i]["id"],currentTree,data)
         }
         else{
-            if(map[data[i]["id"]] !== 1)
+            if(shownNodesMap[data[i]["id"]] !== 1)
             {
-                map[data[i]["id"]] = 0;
+                shownNodesMap[data[i]["id"]] = 0;
             }
         }
     }
     for (let i = 0; i < data.length; i++)
     {
-        if(map[data[i]["id"]] === 1)
+        if(shownNodesMap[data[i]["id"]] === 1)
         {
             RemoveHiddenParents(data[i]["parentIds"]);
         }
@@ -110,7 +111,8 @@ function initGraph() {
   let node = getNodeByTitle(d.currentTarget.__data__.data.title);
   $("#info_box").empty();
   addNodeInfos(node, "preview");
-  updateGraphPlot(currentNodeId);
+    document.getElementById("preview").scrollIntoView({ behavior: 'smooth' });
+    updateGraphPlot(currentNodeId);
 }
 
 /**
@@ -201,7 +203,7 @@ function updateTree(currentNodeId,state){
     }
     for (let i = 0; i < data.length; i++)
     {
-        if(map[data[i]["id"]] === 1)
+        if(shownNodesMap[data[i]["id"]] === 1)
         {
             RemoveHiddenParents(data[i]["parentIds"]);
         }
@@ -303,6 +305,7 @@ function drawTree(drawData,state)
         .on("mouseover", function () { d3.select(this).attr("r", 20); })
         .on("mouseout", function () { d3.select(this).attr("r", 15); })
         .on("click", onNodeInfoClicked);
+    console.log(nodes[0])
 
     nodes.append("circle")
         // .attr("id", "expand")
@@ -340,7 +343,7 @@ function NodeExpand(currentNodeId,currentTree,data)
         if(data[i]["parentIds"].includes(currentNodeId))
         {
             // RemoveHiddenParents(data[i]["parentIds"]);
-            if(map[data[i]["id"]] === 1)
+            if(shownNodesMap[data[i]["id"]] === 1)
             {
                 for(let j = 0;j<currentTree.length;j++)
                 {
@@ -355,7 +358,7 @@ function NodeExpand(currentNodeId,currentTree,data)
                 }
             }
             else{
-                map[data[i]["id"]] = 1;
+                shownNodesMap[data[i]["id"]] = 1;
                 currentTree.push(data[i]);
             }
         }
@@ -378,7 +381,7 @@ function NodeCollapse(currentNodeId,currentTree,data)
                     if(currentTree[i]["parentIds"].length === 0)
                     {
                         childrenQueue.push(currentTree[i]["id"]);
-                        map[currentTree[i]["id"]] = 0;
+                        shownNodesMap[currentTree[i]["id"]] = 0;
                     }
                     break;
                 }
@@ -393,7 +396,7 @@ function NodeCollapse(currentNodeId,currentTree,data)
     let itr = 0;
     while(itr<currentTree.length)
     {
-        if(map[currentTree[itr]["id"]] === 0)
+        if(shownNodesMap[currentTree[itr]["id"]] === 0)
         {
             currentTree.splice(itr, 1);
         }
@@ -409,7 +412,7 @@ function RemoveHiddenParents(parents)
     let j = 0;
     while(j<parents.length)
     {
-        if(map[parents[j]] === 0)
+        if(shownNodesMap[parents[j]] === 0)
         {
             parents.splice(j, 1);
         }

--- a/dag.js
+++ b/dag.js
@@ -367,6 +367,32 @@ function drawTree(drawData,state)
         .on("mouseout", function () { d3.select(this).attr("r", 12); })
         .on("click", onNodeToggleChildrenClicked);
 
+    nodesHaveChildren.append("text")
+        .attr("class", "iText")
+        .attr("x",function (d) {
+            switch (shownNodeChildrenMap[d.data.id]) {
+                case 1:
+                    return nodeWidth/2 - 4.25;
+                default:
+                    return nodeWidth/2 - 7;
+            }
+        })
+        .attr("y",function (d) {
+            switch (shownNodeChildrenMap[d.data.id]) {
+                case 1:
+                    return nodeHeight + 6;
+                default:
+                    return nodeHeight + 8.5;
+            }
+        })
+        .html(function (d) {
+            switch (shownNodeChildrenMap[d.data.id]) {
+                case 1:
+                    return "-";
+                default:
+                    return "+";
+            }
+        })
 }
 /**
  * Search for nodes children and add them to the currentTree
@@ -402,6 +428,7 @@ function NodeExpand(currentNodeId,data)
             nodeChildren.push(data[i]["id"]);
         }
     }
+    ///Link new nodes (clicked node children) to their existing children
     for(let i = 0;i<nodeChildren.length;i++)
     {
         let nodeGrandChildren = getNodeChildren(nodeChildren[i],data);

--- a/dag.js
+++ b/dag.js
@@ -11,7 +11,7 @@ let nodeWidth = maxTextLength + 20;
 let nodeHeight = 140;
 let map = {};
 let currentTree = [];
-let fixedNodes = ["0","1","17","39","50","56","79","81","82","84","102","144"];
+let zoomTransform;
 
 // Define the zoom function for the zoomable tree
 var zoom = d3.zoom()
@@ -19,6 +19,7 @@ var zoom = d3.zoom()
       .on('zoom', function(event) {
         graph
             .attr('transform', event.transform);
+        zoomTransform = event.transform;
 });
 
 // How to draw edges
@@ -46,14 +47,6 @@ function initGraph() {
                 map[data[i]["id"]] = 0;
             }
         }
-        // if(fixedNodes.includes(data[i]["id"]))
-        // {
-        //     map[data[i]["id"]] = 1;
-        //     currentTree.push(data[i]);
-        // }
-        // else{
-        //     map[data[i]["id"]] = 0;
-        // }
     }
     for (let i = 0; i < data.length; i++)
     {
@@ -62,8 +55,7 @@ function initGraph() {
             RemoveHiddenParents(data[i]["parentIds"]);
         }
     }
-    // currentTree = drawData;
-    drawTree(currentTree);
+    drawTree(currentTree,"init");
 }
 
 /**
@@ -76,9 +68,9 @@ function initGraph() {
   let jsonRootFullPath = (window.location.href.includes("localhost") || window.location.href.includes("127.0.")) ?
   `./${jsonDataFile}` : `${host}${dataDict}${jsonDataFile}`;
 
-  var rawFile = new XMLHttpRequest();
+  let rawFile = new XMLHttpRequest();
   rawFile.open("GET", jsonRootFullPath, false);
-  var allText;
+  let allText;
   rawFile.onreadystatechange = function ()
   {
       if(rawFile.readyState === 4)
@@ -214,10 +206,12 @@ function updateTree(currentNodeId,state){
             RemoveHiddenParents(data[i]["parentIds"]);
         }
     }
-    drawTree(currentTree);
+    drawTree(currentTree,"update");
+    graph
+        .attr('transform', zoomTransform);
 }
 
-function drawTree(drawData)
+function drawTree(drawData,state)
 {
     dag = d3.dagStratify()(drawData);
     layout = d3

--- a/helper.js
+++ b/helper.js
@@ -294,3 +294,14 @@ function prepareReferencesInfo(referenceString){
   return value;
 }
 
+function getNodeChildren(nodeId,data)
+{
+  let children = [];
+  data.forEach(function (elem) {
+    if (elem.parentIds.includes(nodeId)) {
+      children.push(elem)
+    }
+  });
+  return children;
+}
+

--- a/helper.js
+++ b/helper.js
@@ -293,7 +293,12 @@ function prepareReferencesInfo(referenceString){
 
   return value;
 }
-
+/**
+ * Get node children
+ * @param {String} nodeId node ID
+ * @param {Array} data tree data
+ * @returns
+ */
 function getNodeChildren(nodeId,data)
 {
   let children = [];

--- a/style.css
+++ b/style.css
@@ -244,7 +244,7 @@ body {
 /*}*/
 
 .node .iText {
-  font-size: 18px;
+  font-size: 25px;
   fill: var(--main-bg);
   pointer-events: none;
   font-family: Georgia, 'Times New Roman', Times, serif;

--- a/style.css
+++ b/style.css
@@ -232,6 +232,16 @@ body {
   opacity: 30%;
 }
 
+/*.node #expand{*/
+/*  fill: darkblue;*/
+/*  opacity: 100%;*/
+/*}*/
+
+/*.node #collapse{*/
+/*  fill: darkred;*/
+/*  opacity: 100%;*/
+/*}*/
+
 .node .iText {
   font-size: 18px;
   fill: var(--main-bg);

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@
 
 body {
   overflow-x: scroll;
+  overflow-y: hidden ;
   background-color: var(--main-bg);
   font-family: "Lato", sans-serif;
 }
@@ -169,7 +170,7 @@ body {
 
 /* content  */
 .content {
-  height: auto;
+  height: 100vh;
   margin-left: var(--sidenav-width);
 }
 
@@ -258,7 +259,9 @@ body {
   margin-top: 20px;
   margin-left: var(--legend-margin-lr);
   margin-right: var(--legend-margin-lr);
-  float: right;
+  position:fixed;
+  bottom:25%;
+  right:0;
 }
 
 .legend .circle {
@@ -285,10 +288,14 @@ body {
 
 /* infobox  */
 .content #info_box {
-  width: 100%;
-  height: auto;
-  margin-top: 20px;
-  display: inline-block;
+  width: calc(100% - var(--sidenav-width));
+  /*margin-top: 20px;*/
+  /*display: inline-block;*/
+  overflow-y: scroll;
+  height: 25%;
+  position:fixed;
+  bottom:0;
+  background-color: white;
 }
 
 .content #info_box .info {
@@ -299,6 +306,8 @@ body {
   margin-right: var(--table-margin-lr);
   margin-bottom: 50px;
   border-top: 1px solid #d6d6d4;
+  /*overflow: hidden;*/
+  /*box-sizing: content-box;*/
 }
 
 .content #info_box .info .infoHead {
@@ -323,6 +332,7 @@ body {
 
 .content #info_box .info #info_key {
   font-weight: bold;
+  display: inline;
 }
 
 /* tree table  */


### PR DESCRIPTION
Now the two or three top layers are only shown, depending on the children of nodes of the top layer. This merge request includes also saving the current zoom state after updating the tree and fixing the info panel at the bottom of the screen as it can be scrolled to show all the info without the need of scrolling the whole page.