### PR TITLE
16 show expand and collapse buttons together

### DIFF
--- a/dag.js
+++ b/dag.js
@@ -403,10 +403,11 @@ function drawTree(drawData,state)
         .attr("class", "node-expand-button")  // Add a class for styling if needed
         .attr("fill",function (d) {
             switch (nodeChildrenStateMap[d.data.id]) {
-                case 1:
-                    return "grey";
-                default:
+                case 0:
+                case 2:
                     return "darkgreen";
+                default:
+                    return "grey";
             }
         })
         .on("click", function(event,d){
@@ -426,6 +427,7 @@ function drawTree(drawData,state)
         .attr("fill",function (d) {
             switch (nodeChildrenStateMap[d.data.id]) {
                 case 1:
+                case 2:
                     return "darkred";
                 default:
                     return "grey";
@@ -576,7 +578,10 @@ function updateShownNodeMap(data)
     for (let i = 0; i < currentTree.length; i++) {
         if (getNodeChildren(currentTree[i]["id"], data).length === getNodeChildren(currentTree[i]["id"], currentTree).length) {
             nodeChildrenStateMap[currentTree[i]["id"]] = 1;
-        } else {
+        } else if (getNodeChildren(currentTree[i]["id"], currentTree).length > 0 ){
+            nodeChildrenStateMap[currentTree[i]["id"]] = 2;
+        }
+        else{
             nodeChildrenStateMap[currentTree[i]["id"]] = 0;
         }
         if (getNodeParents(currentTree[i]["id"], data).length === getNodeParents(currentTree[i]["id"], currentTree).length) {

--- a/dag.js
+++ b/dag.js
@@ -200,11 +200,12 @@ function initGraph() {
 /**
  * Toggle between expanding and collapsing node children
  * @param {Object} d clicked node
+ * @param {String} command identify which action should be executed
  */
-function onNodeChildrenToggle(d){
+function onNodeChildrenToggle(d,command){
     let currentNodeId = d.data.id;
     let state;
-    if(nodeChildrenStateMap[currentNodeId])
+    if(command === "collapse")
     {
         state = "children collapse";
         nodeChildrenStateMap[currentNodeId] = 0;
@@ -411,9 +412,9 @@ function drawTree(drawData,state)
             }
         })
         .on("click", function(event,d){
-            if(!(nodeChildrenStateMap[d.data.id]))
+            if((nodeChildrenStateMap[d.data.id]) === 0 || nodeChildrenStateMap[d.data.id] === 2)
             {
-                onNodeChildrenToggle(d);
+                onNodeChildrenToggle(d,"expand");
             }
         });
 
@@ -436,7 +437,7 @@ function drawTree(drawData,state)
         .on("click", function(event,d){
             if( (nodeChildrenStateMap[d.data.id]))
             {
-                onNodeChildrenToggle(d);
+                onNodeChildrenToggle(d,"collapse");
             }
         });
 


### PR DESCRIPTION
Now the expand and collapse buttons can be enabled at the same time if some of the node children are shown.