### PR TITLE
Modified tree links position and prevent overlapping with sensors links

### DIFF
--- a/sidenav.js
+++ b/sidenav.js
@@ -64,9 +64,9 @@ function addSideNavLinks() {
     });
 
     // after last link, add some space
-    $("<div></div>")
-        .outerHeight($("#side_nav_links").outerHeight() * 0.35)
-        .appendTo($("#side_nav_links"));
+    // $("<div></div>")
+    //     .outerHeight($("#side_nav_links").outerHeight() * 0.35)
+    //     .appendTo($("#side_nav_links"));
 }
 
 /**
@@ -129,9 +129,8 @@ function addTreesLinks()
     const treesLinksContainer = document.createElement('div');
     treesLinksContainer.classList.add('tree_links_container');
 
-    const sideNav = document.getElementById('side_nav_links');
+    const sideNav = document.getElementById('side_nav');
     const currentTreeTitle = document.getElementById('head').getElementsByTagName("a")[0].innerHTML;
-    const content = document.getElementsByClassName('content');
     let repos = ["LidarLimbs", "RadarRami", "UltrasonicUnderwood", "CameraCopse"];
     repos.forEach(function(repo){
         if(repo !== currentTreeTitle) {

--- a/sidenav.js
+++ b/sidenav.js
@@ -41,15 +41,20 @@ function addSideNavLinks() {
 
             this.classList.toggle("active");
             var dropdownContent = this.nextElementSibling;
+            var caretIcon = this.querySelector("i"); // Get the caret icon element
 
             if (dropdownContent.style.display === "block") {
                 dropdownContent.style.display = "none";
                 let index = localALinks.indexOf(this.innerText)
                 localALinks.splice(index, 1);
+                caretIcon.classList.remove("fa-caret-up"); // Remove the up arrow class
+                caretIcon.classList.add("fa-caret-down"); // Add the down arrow class
 
             } else {
                 dropdownContent.style.display = "block";
                 localALinks.push(this.innerText);
+                caretIcon.classList.remove("fa-caret-down"); // Remove the down arrow class
+                caretIcon.classList.add("fa-caret-up"); // Add the up arrow class
             }
             keepDataInSessionStorage(repoName + "ActiveLinks", JSON.stringify(localALinks));
         });

--- a/sidenav.js
+++ b/sidenav.js
@@ -134,7 +134,12 @@ function addTreesLinks()
     const treesLinksContainer = document.createElement('div');
     treesLinksContainer.classList.add('tree_links_container');
 
+    const horizontalLine = document.createElement('hr');
+    horizontalLine.classList.add('h_line');
+
     const sideNav = document.getElementById('side_nav');
+    sideNav.appendChild(horizontalLine)
+
     let repos = ["LidarLimbs", "RadarRami", "UltrasonicUnderwood", "CameraCopse"];
     repos.forEach(function(repo){
         if(repo !== repoName) {

--- a/style.css
+++ b/style.css
@@ -36,7 +36,8 @@ body {
   padding-top: 20px;
   background-color: var(--sidenav-bg);
   box-shadow: 1px 0 1px 0 rgb(214, 211, 211);
-  z-index: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .sidenav #head a {
@@ -128,7 +129,7 @@ body {
 /* sidenav links  */
 #side_nav_links {
   overflow-y: auto;
-  height: 100%;
+  height: 80%;
   width: var(--sidenav-width);
 }
 
@@ -466,6 +467,17 @@ body {
 }
 
 .tree_links_container{
-  position: fixed;
+  position: relative;
   bottom: 0;
+}
+
+.tree_links_container a{
+  width: 100%;
+  padding: 8px 8px 6px 16px;
+  text-align: left;
+  font-size: 14px;
+  color: var(--main-color);
+  display: block;
+  cursor: pointer;
+  text-decoration: none;
 }

--- a/style.css
+++ b/style.css
@@ -156,6 +156,11 @@ body {
   float: right;
 }
 
+#side_nav_links .fa-caret-up {
+  padding-right: 8px;
+  float: right;
+}
+
 #side_nav_links .dropdown-container {
   padding-left: 8px;
   font-size: 10px;

--- a/style.css
+++ b/style.css
@@ -130,6 +130,7 @@ body {
 #side_nav_links {
   overflow-y: auto;
   width: var(--sidenav-width);
+  height: calc(100vh - (/*top padding*/ 20px + /*height of head*/ 30px + /*height of search-container*/ 50px + /*height of infoHead*/ 30px + /*height of tree_links_container*/ 60px + /*offset height*/125px));
 }
 
 #side_nav_links a {

--- a/style.css
+++ b/style.css
@@ -126,11 +126,20 @@ body {
   background-color: var(--sidenav-l-active) !important; 
 }
 
+.sidenav .h_line {
+  height: 1px;
+  display: block;
+  background-color: var(--main-color);;
+  opacity: 0.3;
+  margin-top: 0;
+}
+
 /* sidenav links  */
 #side_nav_links {
   overflow-y: auto;
   width: var(--sidenav-width);
-  height: calc(100vh - (/*top padding*/ 20px + /*height of head*/ 30px + /*height of search-container*/ 50px + /*height of infoHead*/ 30px + /*height of tree_links_container*/ 60px + /*offset height*/125px));
+  height: calc(100vh - (/*top padding*/ 20px + /*height of head*/ 30px + /*height of search-container*/ 50px +
+    /*height of infoHead*/ 30px + /*height of tree_links_container*/ 60px + /*offset height*/125px + /*horizontal separator height*/3px));
 }
 
 #side_nav_links a {

--- a/style.css
+++ b/style.css
@@ -129,7 +129,6 @@ body {
 /* sidenav links  */
 #side_nav_links {
   overflow-y: auto;
-  height: 80%;
   width: var(--sidenav-width);
 }
 
@@ -467,12 +466,13 @@ body {
 }
 
 .tree_links_container{
-  position: relative;
+  position: fixed;
   bottom: 0;
+  background-color: var(--sidenav-bg);
+  width: var(--sidenav-width);
 }
 
 .tree_links_container a{
-  width: 100%;
   padding: 8px 8px 6px 16px;
   text-align: left;
   font-size: 14px;


### PR DESCRIPTION
The tree links shouldn't overlap now with the sensors links.

Also, the scroll bar of the sidnav should stick to the sensors menu height and on zooming in, there will be a scroll bar for the whole sidenav to show the tree links in addition scrolling inside the sensors menu,